### PR TITLE
Remove file loaded from cdn.polyfill.io

### DIFF
--- a/www/simplyedit/index.php
+++ b/www/simplyedit/index.php
@@ -1537,7 +1537,6 @@ EOF;
 		}
 	</script>
 	<script src="sha1.js"></script>
-	<script src="https://cdn.polyfill.io/v2/polyfill.minify.js?features=default,fetch|gated"></script>
 	<script>
 		document.addEventListener('simply-content-loaded', function(){
 			fetch('/data/')


### PR DESCRIPTION
Mitigates the attack as outlined on https://sansec.io/research/polyfill-supply-chain-attack

The original polyfill author recommends [removing Polyfill entirely](https://x.com/triblondon/status/1761852117579427975)